### PR TITLE
Manage Authors names and Bio from GitHub issues in the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ You will need the following things properly installed on your computer.
 
 ## Running / Development
 
-* `ember serve`
+* `ember server --proxy http://localhost:3000`
+* Make sure `rails server` is running from the `bookstore-api` repository
 * Visit your app at [http://localhost:4200](http://localhost:4200).
 * Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
 

--- a/app/components/book-cover.js
+++ b/app/components/book-cover.js
@@ -12,6 +12,7 @@ export default Component.extend({
     },
 
     openThankYouMessage() {
+      this.set('isShowingPurchaseModal', false);
       this.set('isShowingThankYouModal', true);
     },
 

--- a/app/components/book-cover.js
+++ b/app/components/book-cover.js
@@ -12,13 +12,17 @@ export default Component.extend({
     },
 
     openThankYouMessage() {
-      this.set('isShowingPurchaseModal', false);
-      this.set('isShowingThankYouModal', true);
+      this.setProperties({
+        isShowingPurchaseModal: false,
+        isShowingThankYouModal: true
+      });
     },
 
     close() {
-      this.set('isShowingPurchaseModal', false);
-      this.set('isShowingThankYouModal', false);
+      this.setProperties({
+        isShowingPurchaseModal: false,
+        isShowingThankYouModal: false
+      });
       this.get('blurBackground')(false);
     }
 

--- a/app/components/book-cover.js
+++ b/app/components/book-cover.js
@@ -4,15 +4,20 @@ export default Component.extend({
 
   actions: {
 
-    open() {
+    openPurchaseConfirmation() {
       this.get('book').reload().then(() => {
-        this.set('isShowingModal', true);
+        this.set('isShowingPurchaseModal', true);
         this.get('blurBackground')(true);
       });
     },
 
+    openThankYouMessage() {
+      this.set('isShowingThankYouModal', true);
+    },
+
     close() {
-      this.set('isShowingModal', false);
+      this.set('isShowingPurchaseModal', false);
+      this.set('isShowingThankYouModal', false);
       this.get('blurBackground')(false);
     }
 

--- a/app/models/publisher.js
+++ b/app/models/publisher.js
@@ -2,6 +2,7 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   name: DS.attr('string'),
+  biography: DS.attr('string'),
   discount: DS.attr('number'),
   published: DS.hasMany('book')
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,7 +1,6 @@
-<h2 id="title">
-  {{link-to "Our Awesome Bookstore" "books"}}
-</h2>
-
 <div class={{if blur "blur-background" ""}}>
+  <h2 id="title">
+    {{link-to "Our Awesome Bookstore" "books"}}
+  </h2>
   {{outlet}}
 </div>

--- a/app/templates/author.hbs
+++ b/app/templates/author.hbs
@@ -1,6 +1,6 @@
 <h3>{{model.name}}</h3>
 
-<strong>Biography</strong>: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+<strong>Biography</strong>: {{model.biography}}
 
 <h4>Published titles:</h4>
 <ul>

--- a/app/templates/author.hbs
+++ b/app/templates/author.hbs
@@ -1,6 +1,11 @@
 <h3>{{model.name}}</h3>
 
-<strong>Biography</strong>: {{model.biography}}
+<strong>Biography</strong>: 
+{{#if model.biography}}
+  {{model.biography}}
+{{else}}
+  <em>Biography not available</em>
+{{/if}}
 
 <h4>Published titles:</h4>
 <ul>

--- a/app/templates/components/book-cover.hbs
+++ b/app/templates/components/book-cover.hbs
@@ -1,23 +1,35 @@
-<li {{action "open"}} role="button">
+<li {{action "openPurchaseConfirmation"}} role="button">
   <strong>{{book.title}}</strong><br><br>
   <em>by</em>
   {{link-to book.author.name "author" book.author.id class="author" }}
 </li>
-{{#if isShowingModal}}
+{{#if isShowingPurchaseModal}}
   {{#modal-dialog close="close" clickOutsideToClose=true}}
 
-    <div class="modal">
+    <div class="modal modal-purchase-confirmation">
       <h3>Purchase confirmation</h3>
       You want to buy <strong>{{book.title}}</strong> by {{book.author.name}}.
-
-      <p>
-        <button {{action "close"}}>Purchase for ${{book.price}}!</button>
+      <p {{action "openThankYouMessage"}}>
+        <button>Purchase for ${{book.price}}!</button>
       </p>
-
       <p>
-        <em>Thank you! We will e-mail you your e-book</em>
+        <button {{action "close"}}>Cancel</button>
       </p>
+    </div>
 
+  {{/modal-dialog}}
+{{/if}}
+{{#if isShowingThankYouModal}}
+  {{#modal-dialog close="close" clickOutsideToClose=true}}
+
+    <div class="modal modal-thank-you">
+      <h3>Thank you</h3>
+      <p>
+        <em>Thank you for your purchase! We will e-mail you your e-book</em>
+      </p>
+      <p>
+        <button {{action "close"}}>Close</button>
+      </p>
     </div>
 
   {{/modal-dialog}}

--- a/app/templates/components/book-cover.hbs
+++ b/app/templates/components/book-cover.hbs
@@ -9,8 +9,8 @@
     <div class="modal modal-purchase-confirmation">
       <h3>Purchase confirmation</h3>
       You want to buy <strong>{{book.title}}</strong> by {{book.author.name}}.
-      <p {{action "openThankYouMessage"}}>
-        <button>Purchase for ${{book.price}}!</button>
+      <p>
+        <button {{action "openThankYouMessage"}}>Purchase for ${{book.price}}!</button>
       </p>
       <p>
         <button {{action "close"}}>Cancel</button>


### PR DESCRIPTION
## This feature allows the Author's `biography` to be updated from Github Issues
- Templates to include `biography` when viewing authors

## Additional Features
- Thank You message when the user clicks on "Purchase Book for"
- Cancel/Close button on both dialog boxes
- Update README Documentation with setup instructions

## Assumptions
- As per the tutorial, we will assume authors rarely publish books and background reloads will only be needed every hour